### PR TITLE
Fix/update counter and shutdown

### DIFF
--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/NationalArchives.Taxonomy.Batch.Update.OpenSearch.csproj
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/NationalArchives.Taxonomy.Batch.Update.OpenSearch.csproj
@@ -5,6 +5,7 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
     <UserSecretsId>0acc472f-079b-40ce-8c52-b94d0f5becba</UserSecretsId>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/NationalArchives.Taxonomy.Batch.Update.OpenSearch.csproj
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/NationalArchives.Taxonomy.Batch.Update.OpenSearch.csproj
@@ -6,6 +6,7 @@
     <IsTransformWebConfigDisabled>true</IsTransformWebConfigDisabled>
     <UserSecretsId>0acc472f-079b-40ce-8c52-b94d0f5becba</UserSecretsId>
     <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/OpenSearchUpdateParams.cs
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/OpenSearchUpdateParams.cs
@@ -17,5 +17,7 @@ namespace NationalArchives.Taxonomy.Batch
 
         public int MaxInternalQueueSize { get; set; }
         public int WaitMilliseconds { get; set; }
+
+        public int NullCounterHours { get; set; }
     }
 }

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/Program.cs
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/Program.cs
@@ -108,7 +108,7 @@ namespace NationalArchives.Taxonomy.Batch.Update.OpenSearch
                 int maxInternalQueueSize = upDateParams.MaxInternalQueueSize;
                 int nullCounterHours = upDateParams.NullCounterHours;
 
-                Console.WriteLine($"Using a batch size of {bulkUpdateBatchSize} and a queue fetch interval of {queueFetchSleepTime} sceonds for Open Search bulk updates.");
+                Console.WriteLine($"Using a batch size of {bulkUpdateBatchSize} and a queue fetch interval of {queueFetchSleepTime} seconds for Open Search bulk updates.");
 
                 IUpdateStagingQueueReceiver<IaidWithCategories> interimQueue = ctx.GetRequiredService<IUpdateStagingQueueReceiver<IaidWithCategories>>();  
                 IOpenSearchIAViewUpdateRepository updateRepo = ctx.GetRequiredService<IOpenSearchIAViewUpdateRepository>();

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/Program.cs
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/Program.cs
@@ -106,6 +106,7 @@ namespace NationalArchives.Taxonomy.Batch.Update.OpenSearch
                 int queueFetchWaitTime = upDateParams.WaitMilliseconds;
                 int searchDatabaseUpdateInterval = upDateParams.SearchDatabaseUpdateInterval;
                 int maxInternalQueueSize = upDateParams.MaxInternalQueueSize;
+                int nullCounterHours = upDateParams.NullCounterHours;
 
                 Console.WriteLine($"Using a batch size of {bulkUpdateBatchSize} and a queue fetch interval of {queueFetchSleepTime} sceonds for Open Search bulk updates.");
 
@@ -113,7 +114,7 @@ namespace NationalArchives.Taxonomy.Batch.Update.OpenSearch
                 IOpenSearchIAViewUpdateRepository updateRepo = ctx.GetRequiredService<IOpenSearchIAViewUpdateRepository>();
                 ILogger<UpdateOpenSearchService> logger = ctx.GetRequiredService<ILogger<UpdateOpenSearchService>>();
                 return new UpdateOpenSearchService(interimQueue, updateRepo, logger, bulkUpdateBatchSize, 
-                    queueFetchWaitTime, queueFetchSleepTime, searchDatabaseUpdateInterval, maxInternalQueueSize);
+                    queueFetchWaitTime, queueFetchSleepTime, searchDatabaseUpdateInterval, maxInternalQueueSize, nullCounterHours);
             });
 
             services.AddHostedService<UpdateOpenSearchWindowsService>();

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/appsettings.json
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/appsettings.json
@@ -28,7 +28,7 @@
     "SearchDatabaseUpdateInterval": "1000",
     "MaxInternalQueueSize": "1000000",
     "WaitMilliseconds": "20000",
-    "NullCounterHours": "2"
+    "NullCounterHours": "1"
   },
   "DiscoveryOpenSearchParams": {
     "Scheme": "https",
@@ -37,7 +37,7 @@
     "IndexDatabase": "discovery_records",
     "OpenSearchAwsParams": {
       "UseAwsConnection": "false",
-      "OpenSearchConnectionMode": "*",
+      "OpenSearchConnectionMode": "Agnostic",
       "Region": "eu-west-2",
       "RoleArn": "",
       "AccessKey": "??",

--- a/NationalArchives.Taxonomy.Batch.Update.Elastic/appsettings.json
+++ b/NationalArchives.Taxonomy.Batch.Update.Elastic/appsettings.json
@@ -27,7 +27,8 @@
     "QueueFetchSleepTime": "2000",
     "SearchDatabaseUpdateInterval": "1000",
     "MaxInternalQueueSize": "1000000",
-    "WaitMilliseconds": "20000"
+    "WaitMilliseconds": "20000",
+    "NullCounterHours": "2"
   },
   "DiscoveryOpenSearchParams": {
     "Scheme": "https",

--- a/NationalArchives.Taxonomy.Batch/FullReindex/Producers/FullReindexSqsQueueIaidProducer.cs
+++ b/NationalArchives.Taxonomy.Batch/FullReindex/Producers/FullReindexSqsQueueIaidProducer.cs
@@ -7,8 +7,6 @@ using NationalArchives.Taxonomy.Common.Domain.Queue;
 using NationalArchives.Taxonomy.Common.Service;
 using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -19,6 +17,7 @@ namespace NationalArchives.Taxonomy.Batch.FullReindex.Producers
         private readonly FullReIndexIaidPcQueue<string> _pcQueue;
         private readonly IInformationAssetViewService _iaViewService;
         private readonly OpenSearchAssetBrowseParams _openSearchAssetBrowseParams;
+        private readonly string _sqsQueue;
 
         private volatile int _totalCount;
 
@@ -28,11 +27,15 @@ namespace NationalArchives.Taxonomy.Batch.FullReindex.Producers
             _pcQueue = pcQueue;
             _iaViewService = iaViewService;
             _openSearchAssetBrowseParams = openSearchAssetFetchParams;
+            _sqsQueue = qParams.AmazonSqsParams.QueueUrl;
         }
 
         public int TotalIdentifiersFetched => _totalCount;
 
         public int CurrentQueueSize => _pcQueue.Count;
+
+        public string Source => $"Sqs Queue: {_sqsQueue}";
+
         public async Task InitAsync(CancellationToken token)
         {
             try

--- a/NationalArchives.Taxonomy.Batch/FullReindex/Producers/IIAIDProducer.cs
+++ b/NationalArchives.Taxonomy.Batch/FullReindex/Producers/IIAIDProducer.cs
@@ -10,5 +10,7 @@ namespace NationalArchives.Taxonomy.Batch.FullReindex.Producers
         int TotalIdentifiersFetched { get; }
 
         int CurrentQueueSize { get; }
+
+        string Source {  get; }
     }
 }

--- a/NationalArchives.Taxonomy.Batch/NationalArchives.Taxonomy.Batch.csproj
+++ b/NationalArchives.Taxonomy.Batch/NationalArchives.Taxonomy.Batch.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <UserSecretsId>78174f14-bf9a-47ee-8ef8-e2ec7284aa7a</UserSecretsId>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/NationalArchives.Taxonomy.Batch/Service/FullReindexService.cs
+++ b/NationalArchives.Taxonomy.Batch/Service/FullReindexService.cs
@@ -298,7 +298,7 @@ namespace NationalArchives.Taxonomy.Batch.Service
 
         private void OnStarted()
         {
-            _logger.LogInformation("Taxonomy Generator Full Reindex Service has started.");
+            _logger.LogInformation($"Taxonomy Generator Full Reindex Service has started.  Using input IAIDs from {_iaidsProducer.Source}");
 
         }
 

--- a/NationalArchives.Taxonomy.Batch/appsettings.json
+++ b/NationalArchives.Taxonomy.Batch/appsettings.json
@@ -23,9 +23,9 @@
     "Region": "*"
   },
   "DiscoveryOpenSearchParams": {
-    "Scheme": "https",
+    "Scheme": "http",
     "Host": "vpc-",
-    "Port": "443",
+    "Port": "80",
     "IndexDatabase": "discovery_records",
     "OpenSearchAwsParams": {
       "OpenSearchConnectionMode": "*",
@@ -129,5 +129,5 @@
     "CollectionName": "categories"
   },
   "CategorySource": "Mongo",
-  "OperationMode": "Daily_Update" // "Daily_Update" or "Full_Reindex"
+  "OperationMode": "Full_Reindex" // "Daily_Update" or "Full_Reindex"
 }

--- a/Taxonomy.Common/Domain/Queue/AmazonSqsUpdateSender.cs
+++ b/Taxonomy.Common/Domain/Queue/AmazonSqsUpdateSender.cs
@@ -111,7 +111,7 @@ namespace NationalArchives.Taxonomy.Common.Domain.Queue
             {
                 if (!_tcs.Task.IsFaulted)
                 {
-                    _tcs.SetException(ex); 
+                    _tcs.TrySetException(ex); 
                 }
                 return await _tcs.Task;
             }

--- a/Taxonomy.Common/Domain/Repository/Elastic/OpenSearchIAViewRepository.cs
+++ b/Taxonomy.Common/Domain/Repository/Elastic/OpenSearchIAViewRepository.cs
@@ -5,8 +5,6 @@ using NationalArchives.Taxonomy.Common.Domain.Repository.Common;
 using NationalArchives.Taxonomy.Common.Domain.Repository.Lucene;
 using NationalArchives.Taxonomy.Common.Helpers;
 using OpenSearch.Client;
-
-//using Nest;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -216,10 +214,16 @@ namespace NationalArchives.Taxonomy.Common.Domain.Repository.OpenSearch
                 }
                 else  // existing scroll request
                 {
-                    var scrollResponse = _openSearchConnection.ScrollAsync(browseParams.PageSize, scrollId);
-                    if (scrollResponse.Result.Hits.Any())
+                    var scrollResponse = _openSearchConnection.ScrollAsync(browseParams.PageSize, scrollId).Result;
+
+                    if(!scrollResponse.IsValid)
                     {
-                        return new InformationAssetScrollList (scrollId, scrollResponse.Result.Hits.Select(h => h.Id).ToList());
+                        throw new Exception($"Scrolling failure retrieving results from Open Search", scrollResponse.OriginalException);
+                    }
+
+                    if (scrollResponse.Hits.Any())
+                    {
+                        return new InformationAssetScrollList (scrollId, scrollResponse.Hits.Select(h => h.Id).ToList());
                     }
                     else
                     {

--- a/Taxonomy.Common/NationalArchives.Taxonomy.Common.csproj
+++ b/Taxonomy.Common/NationalArchives.Taxonomy.Common.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>netstandard2.1</TargetFramework>
     <RootNamespace>NationalArchives.Taxonomy.Common</RootNamespace>
     <AssemblyName>NationalArchives.Taxonomy.Common</AssemblyName>
+    <AssemblyVersion>1.1.0.0</AssemblyVersion>
+    <FileVersion>1.1.0.0</FileVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Stop Taxonomy update from shutting down if no updates retrieved from SQS for a period of time.