### PR TITLE
Feature/dsls 574 api generate taxonomies

### DIFF
--- a/Taxonomy.Common/Service/Impl/QueryBasedCategoriserService.cs
+++ b/Taxonomy.Common/Service/Impl/QueryBasedCategoriserService.cs
@@ -319,5 +319,21 @@ namespace NationalArchives.Taxonomy.Common.Service
                 throw;
             }
         }
+
+        public async Task<IDictionary<string, List<CategorisationResult>>> CategoriseMultiple(IList<InformationAssetView> assets, IList<Category> cachedCategories)
+        {
+
+            IList<Category> sourceCategories = cachedCategories ?? await _categoryRepository.FindAll();
+
+            try
+            {
+                IDictionary<string, List<CategorisationResult>> listOfCategorisationResultsForAllAssets = await TestCategoriseMultiple(assets.ToArray(), false, sourceCategories);
+                return listOfCategorisationResultsForAllAssets;
+            }
+            catch (Exception e)
+            {
+                throw;
+            }
+        }
     }
 }

--- a/Taxonomy.Common/Service/Impl/QueryBasedCategoriserService.cs
+++ b/Taxonomy.Common/Service/Impl/QueryBasedCategoriserService.cs
@@ -279,7 +279,7 @@ namespace NationalArchives.Taxonomy.Common.Service
             }
         }
 
-        public async Task<IDictionary<string, List<CategorisationResult>>> CategoriseMultiple(string[] docReferences, IList<Category> cachedCategories)
+        public async Task<IDictionary<string, List<CategorisationResult>>> CategoriseMultiple(string[] docReferences, IList<Category> cachedCategories, bool saveResultsToQueue = true)
         {
 
             foreach (string s in docReferences)
@@ -303,10 +303,15 @@ namespace NationalArchives.Taxonomy.Common.Service
                 Console.WriteLine($"Fetched {assets1.Count} from Elastic Search for categorising in {Math.Round(fetchTime.TotalSeconds, 5)} seconds");
 
                 IDictionary<string, List<CategorisationResult>> listOfCategorisationResultsForAllAssets = await TestCategoriseMultiple(assets1.ToArray(), false, sourceCategories);
-                foreach (var listOfCategorisationResults in listOfCategorisationResultsForAllAssets)
+
+                if (saveResultsToQueue)
                 {
-                    SaveResultsToIntermUpdateQueue(listOfCategorisationResults.Key, listOfCategorisationResults.Value); 
+                    foreach (var listOfCategorisationResults in listOfCategorisationResultsForAllAssets)
+                    {
+                        SaveResultsToIntermUpdateQueue(listOfCategorisationResults.Key, listOfCategorisationResults.Value);
+                    } 
                 }
+
                 return listOfCategorisationResultsForAllAssets;
             }
             catch (Exception e)

--- a/Taxonomy.Common/Service/Interface/ICategoriserService.cs
+++ b/Taxonomy.Common/Service/Interface/ICategoriserService.cs
@@ -28,7 +28,7 @@ namespace NationalArchives.Taxonomy.Common.Service
 
         Task<IList<T>> CategoriseSingle(string docReference);
 
-        Task<IDictionary<string, List<T>>> CategoriseMultiple(string[] docReferences, IList<Category> cachedCategories = null);
+        Task<IDictionary<string, List<T>>> CategoriseMultiple(string[] docReferences, IList<Category> cachedCategories = null, bool saveResultsToQueue = true);
 
         /**
          * Categorise a document and save the found categories

--- a/Taxonomy.Common/Service/Interface/ICategoriserService.cs
+++ b/Taxonomy.Common/Service/Interface/ICategoriserService.cs
@@ -1,4 +1,5 @@
 ﻿using NationalArchives.Taxonomy.Common.BusinessObjects;
+using NationalArchives.Taxonomy.Common.Domain;
 using NationalArchives.Taxonomy.Common.Domain.Repository.Mongo;
 using System;
 using System.Collections.Generic;
@@ -29,6 +30,14 @@ namespace NationalArchives.Taxonomy.Common.Service
         Task<IList<T>> CategoriseSingle(string docReference);
 
         Task<IDictionary<string, List<T>>> CategoriseMultiple(string[] docReferences, IList<Category> cachedCategories = null, bool saveResultsToQueue = true);
+
+        /// <summary>
+        /// Category multiple assets where we already have the complete assets, not just the IDs
+        /// </summary>
+        /// <param name="assets">List of InformationAssetView</param>
+        /// <param name="cachedCategories"> Cached Taxonomy categories.</param>
+        /// <returns>A dictionary where the key is the asset ID and the value a list of CategorisationResult</returns>
+        Task<IDictionary<string, List<CategorisationResult>>> CategoriseMultiple(IList<InformationAssetView> assets, IList<Category> cachedCategories = null);
 
         /**
          * Categorise a document and save the found categories
@@ -83,5 +92,6 @@ namespace NationalArchives.Taxonomy.Common.Service
          */
         IList<IAViewUpdate> GetNewCategorisedDocumentsAfterDocumentAndUpToNSecondsInPast(IAViewUpdate afterIAViewUpdate,
             int nbOfSecondsInPast, int limit);
+        
     }
 }

--- a/tna.taxonomy.api/Controllers/TaxonomyController.cs
+++ b/tna.taxonomy.api/Controllers/TaxonomyController.cs
@@ -117,7 +117,7 @@ namespace tna.taxonomy.api.Controllers
 
         [Route("CategoriseMultiple")]
         [HttpPost]
-        public async Task<ActionResult<IDictionary<string, List<CategorisationResult>>>> CategoriseMultiple(IList<string> iaids)
+        public async Task<ActionResult<IDictionary<string, IList<CategorisationResult>>>> CategoriseMultiple(IList<string> iaids)
         {
 
             if (iaids == null || iaids.Count == 0) 
@@ -129,6 +129,33 @@ namespace tna.taxonomy.api.Controllers
             try
             {
                 IDictionary<string, List<CategorisationResult>> results = await _categoriserService.CategoriseMultiple(docReferences: iaids.ToArray(),  saveResultsToQueue: false);
+                return Ok(results);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error on  Categorisation request for multiple documents");
+                return new ContentResult
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                    Content = "An error occurred while processing the request.",
+                    ContentType = "text/plain"
+                };
+            }
+        }
+
+        [Route("CategoriseMultipleRecordAssets")]
+        [HttpPost]
+        public async Task<ActionResult<IDictionary<string, IList<CategorisationResult>>>> CategoriseMultiple(IList<InformationAssetView> assets)
+        {
+            if (assets == null || assets.Count == 0)
+            {
+                _logger.LogError("At least one asset must be provided.");
+                return BadRequest();
+            }
+
+            try
+            {
+                IDictionary<string, List<CategorisationResult>> results = await _categoriserService.CategoriseMultiple(assets: assets);
                 return Ok(results);
             }
             catch (Exception e)

--- a/tna.taxonomy.api/Controllers/TaxonomyController.cs
+++ b/tna.taxonomy.api/Controllers/TaxonomyController.cs
@@ -1,8 +1,9 @@
 ﻿using Microsoft.AspNetCore.Mvc;
 using NationalArchives.Taxonomy.Common;
+using NationalArchives.Taxonomy.Common.BusinessObjects;
 using NationalArchives.Taxonomy.Common.Domain;
 using NationalArchives.Taxonomy.Common.Service;
-using NationalArchives.Taxonomy.Common.BusinessObjects;
+using System.Net;
 
 namespace tna.taxonomy.api.Controllers
 {
@@ -75,7 +76,70 @@ namespace tna.taxonomy.api.Controllers
             catch (Exception e)
             {
                 _logger.LogError(e, $"Error on Test Categorisation of {testCategoriseSingleRequest.DocReference}");
+                return new ContentResult
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                    Content = "An error occurred while processing the request.",
+                    ContentType = "text/plain"
+                };
+            }
+        }
+
+        [Route("CategoriseSingle")]
+        [HttpPost]
+        public async Task<ActionResult<IList<CategorisationResult>>> CategoriseSingle(string iaid)
+        {
+            if (String.IsNullOrEmpty(iaid))
+            {
+                _logger.LogError("No document info supplied for categorisation request!");
                 return BadRequest();
+            }
+
+            try
+            {
+                // N.B. we call TestCategoriseSingle here rather than CategoriseSingle as we just want to get the
+                // results without sending them to the queue (which should be handled by the caller).
+                IList<CategorisationResult> results = await _categoriserService.TestCategoriseSingle(iaid);
+                return Ok(results);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error on Categorisation of {iaid}");
+                return new ContentResult
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                    Content = "An error occurred while processing the request.",
+                    ContentType = "text/plain"
+                };
+            }
+        }
+
+
+        [Route("CategoriseMultiple")]
+        [HttpPost]
+        public async Task<ActionResult<IDictionary<string, List<CategorisationResult>>>> CategoriseMultiple(IList<string> iaids)
+        {
+
+            if (iaids == null || iaids.Count == 0) 
+            {
+                _logger.LogError("At least one asset ID must be provided.");
+                return BadRequest();
+            }
+
+            try
+            {
+                IDictionary<string, List<CategorisationResult>> results = await _categoriserService.CategoriseMultiple(docReferences: iaids.ToArray(),  saveResultsToQueue: false);
+                return Ok(results);
+            }
+            catch (Exception e)
+            {
+                _logger.LogError(e, $"Error on  Categorisation request for multiple documents");
+                return new ContentResult
+                {
+                    StatusCode = (int)HttpStatusCode.InternalServerError,
+                    Content = "An error occurred while processing the request.",
+                    ContentType = "text/plain"
+                };
             }
         }
 

--- a/tna.taxonomy.api/appsettings.json
+++ b/tna.taxonomy.api/appsettings.json
@@ -6,6 +6,21 @@
   },
   "AllowedHosts": "*",
   "CategorySource": "Mongo",
+  "DiscoveryOpenSearchParams": {
+    "Scheme": "https",
+    "Host": "vpc-",
+    "Port": "443",
+    "IndexDatabase": "discovery_records",
+    "OpenSearchAwsParams": {
+      "OpenSearchConnectionMode": "*",
+      "UseAwsConnection": "false",
+      "Region": "eu-west-2",
+      "RoleArn": "",
+      "AccessKey": "??",
+      "SecretKey": "??"
+      //we've to move away from using this and use the profile to access AWS'
+    }
+  },
   "CategoriserLuceneParams": {
     "DefaultTaxonomyField": "textnocasnopunc",
     "QueryFields": [ "TITLE", "DESCRIPTION", "CONTEXT", "CATALOGUE_REFERENCE", "COVERING_DATES" ],

--- a/tna.taxonomy.api/tna.taxonomy.api.csproj
+++ b/tna.taxonomy.api/tna.taxonomy.api.csproj
@@ -13,6 +13,7 @@
       <TreatAsUsed>true</TreatAsUsed>
     </PackageReference>
     <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.5" />
+    <PackageReference Include="Microsoft.OpenApi" Version="2.10.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="SharpCompress" Version="0.49.1" />
     <PackageReference Include="Snappier" Version="1.3.1" />


### PR DESCRIPTION
Added Taxonomy API call to accepted a list of Information Assets, which can then be categorised directly without having to look up the Asset details in OpenSearch (or Mongo).

N.B. Related change to search indexer is here: https://github.com/nationalarchives/ds-discovery-opensearch-indexer/pull/23